### PR TITLE
Add To Cart Example

### DIFF
--- a/app/Http/Livewire/LinkTable.php
+++ b/app/Http/Livewire/LinkTable.php
@@ -31,6 +31,7 @@ class LinkTable extends DataTableComponent
     protected $model = Link::class;
 
     public $filterData = [];
+    public array $cartItems = [];
 
     public array $arrayOfCountries = [];
 
@@ -40,6 +41,7 @@ class LinkTable extends DataTableComponent
 
     public function createOrder(Link $link)
     {
+        $this->cartItems[] = (string) $link->id;
         if (!$link->is_on_order) {
             $this->alert('error', "You already purchased this link!");
             return;
@@ -56,11 +58,13 @@ class LinkTable extends DataTableComponent
 
     public function configure(): void
     {
+ 
         $this->setPrimaryKey('id')
             ->setSingleSortingDisabled()
             ->setOfflineIndicatorEnabled()
             ->setQueryStringDisabled()
             // ->setFilterLayoutSlideDown()
+            ->setTableAttributes(["x-data" => "{ cartItems: \$wire.entangle('cartItems') }"])
             ->setEagerLoadAllRelationsEnabled();
 
         if (empty($this->arrayOfCountries)) {
@@ -90,20 +94,9 @@ class LinkTable extends DataTableComponent
     {
         return [
             Column::make("Cart")
-                ->label(
-                    function ($row, Column $column) {
-                        if ($row->orders->where('user_id', auth()->id())->isEmpty()) {
-                            return '<svg wire:click="createOrder(' . $row->id . ')" class="w-5 h-5 text-blue-600 cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
-                          </svg>';
-                        } else {
-                            return '<svg  class="w-5 h-5 text-gray-600 cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007zM8.625 10.5a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
-                          </svg>';
-                        }
-                    }
-                )
-                ->html(),
+            ->label(
+                fn($row, Column $column) => view('addToCartButton')->withValue($row->id)
+            ),
 
             Column::make("#", "id")
                 ->sortable()
@@ -177,7 +170,7 @@ class LinkTable extends DataTableComponent
         return [
 
             SmartSelectFilter::make('Country', 'cuntry')
-                ->config(['displayHtmlName' => false])
+                ->config(['displayHtmlName' => true])
                 ->options(
                     $this->arrayOfCountries
                 )

--- a/resources/views/addToCartButton.blade.php
+++ b/resources/views/addToCartButton.blade.php
@@ -1,0 +1,12 @@
+<div x-data="{ inCart: cartItems.indexOf('{{ $value }}') > -1 }">
+<div x-show="!inCart">
+<svg x-on:click="inCart = true" wire:click="createOrder('{{$value}}')" class="w-5 h-5 text-blue-600 cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+                          </svg>
+</div>
+<div x-show="inCart">
+<svg x-on:click="inCart = false" class="w-5 h-5 text-gray-600 cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007zM8.625 10.5a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+                          </svg>
+</div>
+</div>


### PR DESCRIPTION
Here's an example of how you can approach using AlpineJS to manage the add to cart icons.

The important bits are:

**At Top**
```php
    public array $cartItems = [];
```

**In Configure()**
```php
            ->setTableAttributes(["x-data" => "{ cartItems: \$wire.entangle('cartItems') }"])
```

**Column Change**
```php
    Column::make("Cart")
    ->label(
        fn($row, Column $column) => view('addToCartButton')->withValue($row->id)
    ),
```

**Add to Cart**
```php
        $this->cartItems[] = (string) $link->id;
```

Then the additional blade for the buttons.

You can add any wire:click that you like to the SVGs, it's the x-on:click="" that does the toggling of the icon.

It will then render the icon correctly after filtering etc, as it will check the entangled cartItems array.