### PR TITLE
Adding "composer initial-setup" command to setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,24 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "initial-setup": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
+            "composer update",
+            "@php -r \"file_exists('database/database.sqlite') || touch database/database.sqlite\"",
+            "@php artisan key:generate",
+            "@php artisan migrate:fresh --seed",
+            "npm i",
+            "npm update",
+            "npm run production",
+            "npm run dev",
+            "@php artisan view:clear",
+            "@php artisan clear-compiled",
+            "@php artisan cache:clear",
+            "@php artisan route:clear",
+            "@php artisan view:clear",
+            "@php artisan config:clear",
+            "@php artisan serve"
         ]
     },
     "extra": {

--- a/config/livewiretablesadvancedfilters.php
+++ b/config/livewiretablesadvancedfilters.php
@@ -42,9 +42,9 @@ return [
             'dateFormat' => 'Y-m-d',
         ],
         // Set to true if you need to include the Flatpickr JS
-        'publishFlatpickrJS' => true,
+        'publishFlatpickrJS' => false,
         // Set to true if you need to include the Flatpickr CSS
-        'publishFlatpickrCSS' => true,
+        'publishFlatpickrCSS' => false,
     ],
     'datePicker' => [
         'defaults' => [


### PR DESCRIPTION
Adds a command
"composer initial-setup"
This runs
- Check for .env file, move .env.example to .env if it doesn't exist
- composer update
- checks for sqlite presence, if not present, touches it
- generates key
- artisan migrate:fresh --seed
- npm install
- npm update
- npm run production
- npm run dev
- view/cache/route clear
- artisan serve